### PR TITLE
Fix proxy-enabled handling

### DIFF
--- a/trusty-interface/Service.h
+++ b/trusty-interface/Service.h
@@ -25,43 +25,115 @@
 
 namespace ama { namespace trusty {
 
+/**
+ * Plain Old Data representing HTTP proxy configuration
+ * data on macOS.
+ *
+ * Specifically, ProxyState is a 3-tuple of (enabled, host, port);
+ * this is true for all of the network protocols that we care
+ * about.
+ */
 class ProxyState
 {
 public:
     ProxyState(bool enabled, const std::string &host, int port) noexcept;
+
+    /**
+     * Initializes ProxyState with the serialized data in the given
+     * payload, which is expected to have been produced from
+     * ProxyState::serialize().
+     *
+     * @param payload a serialized binary representation of ProxyState data.
+     * @throws if the given payload is not comprehensible as a ProxyState.
+     */
     ProxyState(const std::vector<uint8_t>& payload);
+
     ProxyState(const ProxyState&) = default;
-    ProxyState(ProxyState&&) noexcept = default;
+    ProxyState(ProxyState&&) = default;
+    ProxyState& operator=(const ProxyState&) = default;
+    ProxyState& operator=(ProxyState&&) = default;
 
     bool is_enabled() const noexcept { return enabled_; }
     const std::string& get_host() const noexcept { return host_; }
     int32_t get_port() const noexcept { return port_; }
 
+    /**
+     * Returns a representation of this instance as a vector of bytes,
+     * suitable for transmitting over the wire.
+     *
+     * @return a vector of bytes representing the data in this instance.
+     */
     std::vector<uint8_t> serialize() const;
+
 private:
     bool enabled_;
     std::string host_;
     int32_t port_;
 };
 
-/*!
+/**
+ * Defines the RPC interface between Amanuensis and Trusty.
  *
+ * IService is a pure, virtual, synchronous, interface.  Errors
+ * are communicated via exceptions - all interface methods are
+ * permitted to throw, and callers are advised to expect exceptions.
  */
 class IService
 {
 public:
     virtual ~IService() {}
 
+    /**
+     * Gets the HTTP proxy settings for the currently-active
+     * network service.
+     *
+     * If no settings are configured, the return will be
+     * default-initialized as disabled, with an empty hostname.
+     * There is no distinction between having an empty hostname
+     * configured in the system preferences and having _no_ hostname
+     * so configured; therefore, that distinction is not modeled.
+     *
+     * @return a ProxyState instance containing current HTTP proxy settings.
+     */
     virtual ProxyState get_http_proxy_state() = 0;
-    virtual void set_http_proxy_state(const ProxyState& endpoint) = 0;
 
+    /**
+     * Updates the HTTP proxy settings for the currently-active
+     * network service.
+     *
+     * If the given state has an empty hostname, service implementations
+     * will also set the proxy to disabled.
+     *
+     * @param state
+     */
+    virtual void set_http_proxy_state(const ProxyState& state) = 0;
+
+    /**
+     * Undo any settings alterations made by Trusty, restoring the system's
+     * proxy settings to their initial state.
+     *
+     * Not implemented, and may possibly be removed in favor of implementing
+     * state in Amanuensis itself, instead of in Trusty.
+     */
     virtual void reset_proxy_settings() = 0;
 
+    /**
+     * Gets a number identifying the current service version.
+     *
+     * Version changes are introduced whenever the trusty-interface
+     * or trusty code changes.  They are used to indicate that a new
+     * version of the priviliged helper tool needs to be installed.
+     *
+     * The version number is defined in the file "TrustyCommon.h".
+     *
+     * @return the current version number.
+     */
     virtual uint32_t get_current_version() = 0;
 };
 
-/*! Creates an IService implementation, and connects it to
- *  the server listening on the given UNIX socket @p path.
+/**
+ * Creates an IService implementation, and connects it to
+ * the server listening on the given UNIX socket @p path.
  *
  * @param path an absolute path to a UNIX socket.
  * @return a unique pointer to the connected IService.

--- a/trusty/TrustyService.h
+++ b/trusty/TrustyService.h
@@ -21,14 +21,9 @@
 #include <cstdint>
 #include <string>
 
-#include <SystemConfiguration/SystemConfiguration.h>
-
-#include "CFRef.h"
 #include "Service.h"
 
 namespace ama { namespace trusty {
-
-template <> class is_cfref<SCDynamicStoreRef> : public std::true_type {};
 
 /*! The trusted IService implementation.
  *
@@ -39,17 +34,12 @@ template <> class is_cfref<SCDynamicStoreRef> : public std::true_type {};
 class TrustyService : public IService
 {
 public:
-    TrustyService();
-
     ProxyState get_http_proxy_state() override;
     void set_http_proxy_state(const ProxyState& state) override;
 
     void reset_proxy_settings() override;
 
     uint32_t get_current_version() override;
-
-private:
-    CFRef<SCDynamicStoreRef> ref_;
 };
 
 }} // ama::trusty


### PR DESCRIPTION
Was mistakenly using SCNetworkProtocolGetEnabled and its setter
partner; this does not actually control whether a given HTTP proxy is
considered "active".  Instead, we'll now manually specify HTTPEnable.

This commit also fixes a use-after-free error in cfstring_as_std_string
by switching to use CFStringGetBytes, using a vector as a temporary
buffer.