### PR TITLE
Add unit tests for trusty-interface and refactor.

### DIFF
--- a/amanuensis.pro
+++ b/amanuensis.pro
@@ -32,10 +32,12 @@ macx {
 
     SUBDIRS += \
         trusty \
-        trusty-interface
+        trusty-interface \
+        trusty-test \
 
     trusty.depends = trusty-interface
     app.depends += trusty-interface
+    trusty-test.depends = trusty
 
     BUNDLEAPP = Amanuensis
     HELPERAPP = com.bendb.amanuensis.Trusty

--- a/trusty-interface/MessageProcessor.cpp
+++ b/trusty-interface/MessageProcessor.cpp
@@ -20,88 +20,10 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <system_error>
-
-#include <errno.h>
-#include <poll.h>
-#include <syslog.h>
-#include <sys/fcntl.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/un.h>
-#include <unistd.h>
 
 #include "TrustyCommon.h"
 
 namespace ama { namespace trusty {
-
-namespace
-{
-
-/**
- * @brief Fully writes the given data to a file descriptor,
- *        throwing if all the data cannot be written.
- *
- * @param fd an open socket descriptor
- * @param data a pointer to the data to be written
- * @param len the number of bytes to be written
- * @throws std::system_error on failure.
- */
-template <typename T, size_t S = sizeof(T)>
-void checked_write(int fd, T* data, size_t len)
-{
-    static_assert(S == 1, "Only byte-sized types enabled");
-
-    while (len > 0)
-    {
-        ssize_t num_written = ::write(fd, data, len);
-        if (num_written == -1)
-        {
-            int ec = errno;
-            if (ec == EINTR)
-            {
-                // try again
-                continue;
-            }
-
-            throw std::system_error(ec, std::system_category());
-        }
-
-        data += num_written;
-        len -= num_written;
-    }
-}
-
-template <typename T, size_t S = sizeof(T)>
-void checked_read(int fd, T* data, size_t len)
-{
-    static_assert(S == 1, "Only byte-sized types are allowed");
-
-    while (len > 0)
-    {
-        ssize_t num_read = ::read(fd, data, len);
-        if (num_read == -1)
-        {
-            int ec = errno;
-            if (ec == EINTR)
-            {
-                continue;
-            }
-
-            throw std::system_error(ec, std::system_category());
-        }
-
-        if (num_read == 0)
-        {
-            throw std::runtime_error("Connected is unexpectedly closed");
-        }
-
-        data += num_read;
-        len -= num_read;
-    }
-}
-
-} // namespace
 
 std::ostream& operator<<(std::ostream &out, const MessageType &type)
 {
@@ -177,105 +99,25 @@ std::string Message::get_string_payload() const
 
 /////////
 
-const size_t MessageProcessor::kBufLen; // needs to be defined here, but its value is given in the header file.
+constexpr size_t MessageProcessor::kBufLen; // needs to be defined here, but its value is given in the header file.
 
 MessageProcessor::MessageProcessor(const std::string &path)
-    : fd(0)
+    : socket_(std::make_unique<UnixSocket>(path))
 {
-    int socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
-    if (socket_fd == -1)
-    {
-        int error_code = errno;
-        std::cerr << "socket() failed: " << error_code << std::endl;
-        throw std::system_error(error_code, std::system_category());
-    }
-
-    struct sockaddr_un address = {};
-    ::bzero(&address, sizeof(address));
-
-    address.sun_family = AF_UNIX;
-    ::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
-
-    long opts = ::fcntl(socket_fd, F_GETFL, NULL);
-    opts |= O_NONBLOCK;
-    ::fcntl(socket_fd, F_SETFL, opts);
-
-    int connect_result = ::connect(socket_fd, (const struct sockaddr *) &address, sizeof(address));
-    if (connect_result == -1)
-    {
-        int error_value = errno;
-        if (error_value != EINPROGRESS)
-        {
-            std::cerr << "Failed to connect; errno=" << error_value << std::endl;
-
-            close(socket_fd);
-            throw std::system_error(errno, std::system_category());
-        }
-
-        do
-        {
-            timeval tv { 0, 100000 }; // 1/10 of a second
-            fd_set fds;
-            FD_ZERO(&fds);
-            FD_SET(socket_fd, &fds);
-
-            int select_result = ::select(socket_fd + 1, NULL, &fds, NULL, &tv);
-            if (select_result < 0 && errno != EINTR)
-            {
-                // problem
-                close(socket_fd);
-                throw std::system_error(errno, std::system_category());
-            }
-
-            if (select_result == 0)
-            {
-                // timeout
-                close(socket_fd);
-                throw ama::timeout_exception();
-            }
-
-            int valopt;
-            socklen_t lon = sizeof(int);
-            if (::getsockopt(socket_fd, SOL_SOCKET, SO_ERROR, (void*)(&valopt), &lon) < 0)
-            {
-                // Can't getsockopt
-                close(socket_fd);
-                throw std::system_error(errno, std::system_category());
-            }
-
-            if (valopt > 0)
-            {
-                // socket wasn't selected for write, ergo we aren't connected.
-                // not a timeout though...
-                close(socket_fd);
-                throw std::runtime_error("connection failed");
-            }
-
-            // We're connected!
-            break;
-        } while(true);
-    }
-
-    // Clear O_NONBLOCK
-    opts = ::fcntl(socket_fd, F_GETFL, NULL);
-    opts &= (~O_NONBLOCK);
-    ::fcntl(socket_fd, F_SETFL, opts);
-
-    this->fd = socket_fd;
 }
 
 MessageProcessor::MessageProcessor(int fd)
-    : fd(fd)
+    : socket_(std::make_unique<UnixSocket>(fd))
 {
-    // no-op
+}
+
+MessageProcessor::MessageProcessor(std::unique_ptr<ISocket>&& socket)
+    : socket_(std::move(socket))
+{
 }
 
 MessageProcessor::~MessageProcessor()
 {
-    if (fd != 0)
-    {
-        close(fd);
-    }
 }
 
 /* The wire format is simple.  A message is written as:
@@ -284,14 +126,14 @@ MessageProcessor::~MessageProcessor()
  * payload: <payload length> octets
  */
 
-void MessageProcessor::send(const Message &message) const
+void MessageProcessor::send(const Message &message)
 {
     uint8_t type = static_cast<uint8_t>(message.type);
     uint32_t payload_length = static_cast<uint32_t>(message.payload.size());
 
-    checked_write(fd, &type, sizeof(uint8_t));
-    checked_write(fd, (uint8_t *) &payload_length, sizeof(uint32_t));
-    checked_write(fd, (uint8_t *) message.payload.data(), message.payload.size());
+    socket_->checked_write(&type, sizeof(uint8_t));
+    socket_->checked_write((uint8_t *) &payload_length, sizeof(uint32_t));
+    socket_->checked_write((uint8_t *) message.payload.data(), message.payload.size());
 }
 
 Message MessageProcessor::recv()
@@ -300,8 +142,8 @@ Message MessageProcessor::recv()
     uint8_t type;
     uint32_t length;
 
-    checked_read<uint8_t>(fd, &type, sizeof(uint8_t));
-    checked_read<uint8_t>(fd, (uint8_t *) &length, sizeof(uint32_t));
+    socket_->checked_read(&type, sizeof(uint8_t));
+    socket_->checked_read((uint8_t *) &length, sizeof(uint32_t));
 
     // I think there's a theoretical bug here, in that size_t isn't
     // *guaranteed* to be 32 bits wide; it could, technically, be only
@@ -322,7 +164,7 @@ Message MessageProcessor::recv()
     {
         size_t to_read = std::min(len, kBufLen);
 
-        checked_read(fd, read_buffer, to_read);
+        socket_->checked_read(read_buffer, to_read);
         result.payload.insert(result.payload.end(), &read_buffer[0], &read_buffer[to_read]);
 
         len -= to_read;

--- a/trusty-interface/MessageProcessor.h
+++ b/trusty-interface/MessageProcessor.h
@@ -21,14 +21,16 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
+
+#include "UnixSocket.h"
 
 namespace ama { namespace trusty {
 
 enum class MessageType : uint8_t
 {
-
     /**
      * A reply, indicating that the last message was processed successfully.
      *
@@ -138,9 +140,10 @@ class MessageProcessor
 public:
     MessageProcessor(const std::string &path);
     MessageProcessor(int fd);
+    MessageProcessor(std::unique_ptr<ISocket>&& socket);
     ~MessageProcessor();
 
-    void send(const Message &message) const;
+    void send(const Message &message);
     Message recv();
 
 private:
@@ -155,17 +158,17 @@ private:
      * We can assume that nearly all payloads will be will be tiny;
      * 64 bytes should be more than enough.
      */
-    static const size_t kBufLen = 64;
-
-    /**
-     * A file-descriptor of a connected socket.
-     */
-    int fd;
+    static constexpr size_t kBufLen = 64;
 
     /**
      * A buffer used when reading data from [fd].
      */
     uint8_t read_buffer[kBufLen];
+
+    /**
+     * A file-descriptor of a connected socket.
+     */
+    std::unique_ptr<ISocket> socket_;
 };
 
 }} // ama::trusty

--- a/trusty-interface/ProxyState.cpp
+++ b/trusty-interface/ProxyState.cpp
@@ -1,0 +1,66 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "ProxyState.h"
+
+namespace ama { namespace trusty {
+
+ProxyState::ProxyState(bool enabled, const std::string &host, int port) noexcept
+    : enabled_(enabled)
+    , host_(host)
+    , port_(port)
+{}
+
+ProxyState::ProxyState(const std::vector<uint8_t> &payload)
+{
+    // Serialization format is:
+    // 0: enabled (0 == disabled, !0 == enabled)
+    // 1-4: port, as int32_t
+    // 5-: host, as character data, not null-terminated.
+
+    if (payload.size() < 5)
+    {
+        throw std::invalid_argument{"payload too small to be a ProxyState"};
+    }
+
+    enabled_ = payload[0] != 0;
+    port_ = *((int32_t*) (payload.data() + 1));
+
+    if (payload.size() > 5)
+    {
+        // This would be safe, but just to be paranoid, let's avoid doing anything
+        // with a pointer to invalid memory.
+        host_.assign(reinterpret_cast<const char *>(payload.data() + 5), payload.size() - 5);
+    }
+}
+
+std::vector<uint8_t> ProxyState::serialize() const
+{
+    size_t size = 5 + host_.size();
+    std::vector<uint8_t> payload;
+    payload.reserve(size);
+
+    payload.push_back(enabled_ ? 1 : 0);
+    payload.resize(payload.size() + sizeof(int32_t));
+    ::memcpy(payload.data() + 1, &port_, sizeof(int32_t));
+
+    std::copy(host_.begin(), host_.end(), std::back_inserter(payload));
+
+    return payload;
+}
+
+}} // namespace ama::trusty

--- a/trusty-interface/ProxyState.h
+++ b/trusty-interface/ProxyState.h
@@ -1,0 +1,75 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef PROXYSTATE_H
+#define PROXYSTATE_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ama { namespace trusty {
+
+/**
+ * Plain Old Data representing HTTP proxy configuration
+ * data on macOS.
+ *
+ * Specifically, ProxyState is a 3-tuple of (enabled, host, port);
+ * this is true for all of the network protocols that we care
+ * about.
+ */
+class ProxyState
+{
+public:
+    ProxyState(bool enabled, const std::string &host, int port) noexcept;
+
+    /**
+     * Initializes ProxyState with the serialized data in the given
+     * payload, which is expected to have been produced from
+     * ProxyState::serialize().
+     *
+     * @param payload a serialized binary representation of ProxyState data.
+     * @throws if the given payload is not comprehensible as a ProxyState.
+     */
+    ProxyState(const std::vector<uint8_t>& payload);
+
+    ProxyState(const ProxyState&) = default;
+    ProxyState(ProxyState&&) = default;
+    ProxyState& operator=(const ProxyState&) = default;
+    ProxyState& operator=(ProxyState&&) = default;
+
+    bool is_enabled() const noexcept { return enabled_; }
+    const std::string& get_host() const noexcept { return host_; }
+    int32_t get_port() const noexcept { return port_; }
+
+    /**
+     * Returns a representation of this instance as a vector of bytes,
+     * suitable for transmitting over the wire.
+     *
+     * @return a vector of bytes representing the data in this instance.
+     */
+    std::vector<uint8_t> serialize() const;
+
+private:
+    bool enabled_;
+    std::string host_;
+    int32_t port_;
+};
+
+}} // namespace ama::trusty
+
+#endif // PROXYSTATE_H

--- a/trusty-interface/Service.cpp
+++ b/trusty-interface/Service.cpp
@@ -22,7 +22,7 @@
 
 #include "MessageProcessor.h"
 
-using namespace ama::trusty;
+namespace ama { namespace trusty {
 
 namespace
 {
@@ -138,46 +138,12 @@ void MessageProcessorServiceClient::authenticate(const std::vector<uint8_t> &aut
 
 } // namespace
 
-ProxyState::ProxyState(bool enabled, const std::string &host, int port) noexcept
-    : enabled_(enabled)
-    , host_(host)
-    , port_(port)
-{}
-
-ProxyState::ProxyState(const std::vector<uint8_t> &payload)
-{
-    // Format is:
-    // 0: enabled (0 == disabled, !0 == enabled)
-    // 1-4: port, as int32_t
-    // 5-: host
-
-    if (payload.size() < 5) throw std::invalid_argument{"payload too small to be a ProxyState"};
-
-
-    enabled_ = payload[0] != 0;
-    port_ = *((int32_t*) (payload.data() + 1));
-    host_.assign(reinterpret_cast<const char *>(payload.data() + 5), payload.size() - 5);
-}
-
-std::vector<uint8_t> ProxyState::serialize() const
-{
-    size_t size = 5 + host_.size();
-    std::vector<uint8_t> payload;
-    payload.reserve(size);
-
-    payload.push_back(enabled_ ? 1 : 0);
-    payload.resize(payload.size() + sizeof(int32_t));
-    ::memcpy(payload.data() + 1, &port_, sizeof(int32_t));
-
-    std::copy(host_.begin(), host_.end(), std::back_inserter(payload));
-
-    return payload;
-}
-
-std::unique_ptr<IService> ama::trusty::create_client(const std::string &address, const std::vector<uint8_t> &auth)
+std::unique_ptr<IService> create_client(const std::string &address, const std::vector<uint8_t> &auth)
 {
     std::unique_ptr<MessageProcessorServiceClient> svc = std::make_unique<MessageProcessorServiceClient>(address);
     svc->authenticate(auth);
 
     return std::move(svc);
 }
+
+}} // namespace ama::trusty

--- a/trusty-interface/Service.h
+++ b/trusty-interface/Service.h
@@ -20,56 +20,10 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
-#include <vector>
+
+#include "ProxyState.h"
 
 namespace ama { namespace trusty {
-
-/**
- * Plain Old Data representing HTTP proxy configuration
- * data on macOS.
- *
- * Specifically, ProxyState is a 3-tuple of (enabled, host, port);
- * this is true for all of the network protocols that we care
- * about.
- */
-class ProxyState
-{
-public:
-    ProxyState(bool enabled, const std::string &host, int port) noexcept;
-
-    /**
-     * Initializes ProxyState with the serialized data in the given
-     * payload, which is expected to have been produced from
-     * ProxyState::serialize().
-     *
-     * @param payload a serialized binary representation of ProxyState data.
-     * @throws if the given payload is not comprehensible as a ProxyState.
-     */
-    ProxyState(const std::vector<uint8_t>& payload);
-
-    ProxyState(const ProxyState&) = default;
-    ProxyState(ProxyState&&) = default;
-    ProxyState& operator=(const ProxyState&) = default;
-    ProxyState& operator=(ProxyState&&) = default;
-
-    bool is_enabled() const noexcept { return enabled_; }
-    const std::string& get_host() const noexcept { return host_; }
-    int32_t get_port() const noexcept { return port_; }
-
-    /**
-     * Returns a representation of this instance as a vector of bytes,
-     * suitable for transmitting over the wire.
-     *
-     * @return a vector of bytes representing the data in this instance.
-     */
-    std::vector<uint8_t> serialize() const;
-
-private:
-    bool enabled_;
-    std::string host_;
-    int32_t port_;
-};
 
 /**
  * Defines the RPC interface between Amanuensis and Trusty.
@@ -141,7 +95,7 @@ public:
  */
 std::unique_ptr<IService> create_client(const std::string &path, const std::vector<uint8_t> &auth);
 
-} // namespace trusty
-} // namespace ama
+}} // namespace ama::trusty
+
 
 #endif // ISERVICE_H

--- a/trusty-interface/UnixSocket.cpp
+++ b/trusty-interface/UnixSocket.cpp
@@ -1,0 +1,181 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "UnixSocket.h"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/fcntl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <system_error>
+
+#include "TrustyCommon.h"
+
+namespace ama { namespace trusty {
+
+UnixSocket::UnixSocket(const std::string &path)
+    : fd_(0)
+{
+    int socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (socket_fd == -1)
+    {
+        int error_code = errno;
+        std::cerr << "socket() failed: " << error_code << std::endl;
+        throw std::system_error(error_code, std::system_category());
+    }
+
+    struct sockaddr_un address = {};
+    ::memset(&address, 0, sizeof(address));
+
+    address.sun_family = AF_UNIX;
+    ::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+
+    long opts = ::fcntl(socket_fd, F_GETFL, NULL);
+    opts |= O_NONBLOCK;
+    ::fcntl(socket_fd, F_SETFL, opts);
+
+    int connect_result = ::connect(socket_fd, (const struct sockaddr *) &address, sizeof(address));
+    if (connect_result == -1)
+    {
+        int error_value = errno;
+        if (error_value != EINPROGRESS)
+        {
+            std::cerr << "Failed to connect; errno=" << error_value << std::endl;
+
+            ::close(socket_fd);
+            throw std::system_error(errno, std::system_category());
+        }
+
+        do
+        {
+            timeval tv { 0, 100000 }; // 1/10 of a second
+            fd_set fds;
+            FD_ZERO(&fds);
+            FD_SET(socket_fd, &fds);
+
+            int select_result = ::select(socket_fd + 1, NULL, &fds, NULL, &tv);
+            if (select_result < 0 && errno != EINTR)
+            {
+                // problem
+                ::close(socket_fd);
+                throw std::system_error(errno, std::system_category());
+            }
+
+            if (select_result == 0)
+            {
+                // timeout
+                ::close(socket_fd);
+                throw ama::timeout_exception();
+            }
+
+            int valopt;
+            socklen_t lon = sizeof(int);
+            if (::getsockopt(socket_fd, SOL_SOCKET, SO_ERROR, (void*)(&valopt), &lon) < 0)
+            {
+                // Can't getsockopt
+                ::close(socket_fd);
+                throw std::system_error(errno, std::system_category());
+            }
+
+            if (valopt > 0)
+            {
+                // socket wasn't selected for write, ergo we aren't connected.
+                // not a timeout though...
+                ::close(socket_fd);
+                throw std::runtime_error("connection failed");
+            }
+
+            // We're connected!
+            break;
+        } while(true);
+    }
+
+    // Clear O_NONBLOCK
+    opts = ::fcntl(socket_fd, F_GETFL, NULL);
+    opts &= (~O_NONBLOCK);
+    ::fcntl(socket_fd, F_SETFL, opts);
+
+    this->fd_ = socket_fd;
+}
+
+UnixSocket::UnixSocket(int fd) noexcept
+    : fd_(fd)
+{
+}
+
+UnixSocket::~UnixSocket() noexcept
+{
+    if (fd_ != 0)
+    {
+        ::close(fd_);
+    }
+}
+
+void UnixSocket::checked_write(uint8_t* data, size_t len)
+{
+    while (len > 0)
+    {
+        ssize_t num_written = ::write(fd_, data, len);
+        if (num_written == -1)
+        {
+            int ec = errno;
+            if (ec == EINTR)
+            {
+                // try again
+                continue;
+            }
+
+            throw std::system_error(ec, std::system_category());
+        }
+
+        data += num_written;
+        len -= num_written;
+    }
+}
+
+void UnixSocket::checked_read(uint8_t* data, size_t len)
+{
+    while (len > 0)
+    {
+        ssize_t num_read = ::read(fd_, data, len);
+        if (num_read == -1)
+        {
+            int ec = errno;
+            if (ec == EINTR)
+            {
+                continue;
+            }
+
+            throw std::system_error(ec, std::system_category());
+        }
+
+        if (num_read == 0)
+        {
+            throw std::runtime_error("Connected is unexpectedly closed");
+        }
+
+        data += num_read;
+        len -= num_read;
+    }
+}
+
+}} // namespace ama::trusty

--- a/trusty-interface/UnixSocket.h
+++ b/trusty-interface/UnixSocket.h
@@ -1,0 +1,86 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef UNIXSOCKET_H
+#define UNIXSOCKET_H
+
+#include <cstdint>
+#include <string>
+
+namespace ama { namespace trusty {
+
+class ISocket
+{
+public:
+    virtual ~ISocket() = default;
+
+    /**
+     * Fully writes the given data, throwing if all the data cannot be written.
+     *
+     * @param data a pointer to the data to be written
+     * @param len the number of bytes to be written
+     * @throws std::system_error on failure.
+     */
+    virtual void checked_write(uint8_t* data, size_t len) = 0;
+
+    /**
+     * Fully reads the given amount of data, throwing if the expected amount
+     * of data cannot be read.
+     *
+     * @param data a pointer to the data buffer.
+     * @param len the number of bytes to read.
+     * @throws std::system_error on failure.
+     */
+    virtual void checked_read(uint8_t* data, size_t len) = 0;
+};
+
+/**
+ * Implements ISocket using a UNIX-family socket, initialized
+ * either with an already-open file descriptor or with the absolute
+ * filesystem path of the socket to be opened.
+ *
+ * Closes the file descriptor on destruction.
+ */
+class UnixSocket : public ISocket
+{
+public:
+    /**
+     * Initializes a UnixSocket by opening the socket at the given path.
+     * @param path the path of the socket to open.
+     */
+    UnixSocket(const std::string& path);
+
+    /**
+     * Initializes a UnixSocket, taking ownership of the given (open) file descriptor.
+     * @param fd a descriptor for an open socket.
+     */
+    UnixSocket(int fd) noexcept;
+
+    ~UnixSocket() noexcept;
+
+    void checked_write(uint8_t* data, size_t len) override;
+
+    void checked_read(uint8_t* data, size_t len) override;
+
+private:
+    int fd_;
+};
+
+}} // namespace ama::trusty
+
+
+#endif // UNIXSOCKET_H

--- a/trusty-interface/trusty-interface.pro
+++ b/trusty-interface/trusty-interface.pro
@@ -14,9 +14,13 @@ HEADERS += \
     TrustyCommon.h \
     MessageProcessor.h \
     Service.h \
-    CFRef.h
+    CFRef.h \
+    ProxyState.h \
+    UnixSocket.h
 
 SOURCES += \
     MessageProcessor.cpp \
     Service.cpp \
-    TrustyCommon.cpp
+    TrustyCommon.cpp \
+    ProxyState.cpp \
+    UnixSocket.cpp

--- a/trusty-test/MessageProcessorTest.cpp
+++ b/trusty-test/MessageProcessorTest.cpp
@@ -1,0 +1,22 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "MessageProcessorTest.h"
+
+MessageProcessorTest::MessageProcessorTest()
+{
+}

--- a/trusty-test/MessageProcessorTest.h
+++ b/trusty-test/MessageProcessorTest.h
@@ -1,0 +1,34 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MESSAGEPROCESSORTEST_H
+#define MESSAGEPROCESSORTEST_H
+
+#include <QObject>
+
+class MessageProcessorTest : public QObject
+{
+    Q_OBJECT
+public:
+    MessageProcessorTest();
+
+private Q_SLOTS:
+    // TODO: write tests using a mocked ISocket
+
+};
+
+#endif // MESSAGEPROCESSORTEST_H

--- a/trusty-test/ProxyStateTest.cpp
+++ b/trusty-test/ProxyStateTest.cpp
@@ -1,0 +1,49 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "ProxyStateTest.h"
+
+#include <string>
+#include <sstream>
+
+#include <QString>
+#include <QtTest>
+
+#include "ProxyState.h"
+
+using namespace ama::trusty;
+
+ProxyStateTest::ProxyStateTest()
+{
+}
+
+void ProxyStateTest::serialize()
+{
+    ProxyState state(true, "google.com", 0x0000FFFF);
+    std::vector<uint8_t> expected{1, 0xFF, 0xFF, 0x00, 0x00, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'o', 'm' };
+    std::vector<uint8_t> actual = state.serialize();
+    QCOMPARE(expected, actual);
+}
+
+void ProxyStateTest::deserialize_empty_host()
+{
+    std::vector<uint8_t> serialized{0, 0, 0, 0, 0}; // disabled, port=0, host=""
+    ProxyState state{serialized};
+    QCOMPARE(std::string{""}, state.get_host());
+    QCOMPARE(false, state.is_enabled());
+    QCOMPARE(0, state.get_port());
+}

--- a/trusty-test/ProxyStateTest.h
+++ b/trusty-test/ProxyStateTest.h
@@ -1,0 +1,36 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef PROXYSTATETEST_H
+#define PROXYSTATETEST_H
+
+#include <QObject>
+
+class ProxyStateTest : public QObject
+{
+    Q_OBJECT
+
+public:
+    ProxyStateTest();
+
+private Q_SLOTS:
+    void serialize();
+
+    void deserialize_empty_host();
+};
+
+#endif // PROXYSTATETEST_H

--- a/trusty-test/main.cpp
+++ b/trusty-test/main.cpp
@@ -1,0 +1,51 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cerrno>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <QCoreApplication>
+#include <QtTest>
+
+// Include test files
+#include "MessageProcessorTest.h"
+#include "ProxyStateTest.h"
+
+int main(int argc, char **argv)
+{
+    QCoreApplication application(argc, argv);
+    QStringList arguments = QCoreApplication::arguments();
+
+    std::unordered_map<std::string, std::unique_ptr<QObject>> tests;
+    tests.emplace("MessageProcessorTests", std::make_unique<MessageProcessorTest>());
+    tests.emplace("ProxyStateTest", std::make_unique<ProxyStateTest>());
+
+    int status = 0;
+    for (auto& kvp : tests)
+    {
+        // QApplication's ctor sometimes leaves errno set to EINVAL.
+        // Some tests may also alter errno.  In any case, let's start
+        // our tests with a blank slate.
+        errno = 0;
+
+        auto& test = kvp.second;
+        status |= QTest::qExec(test.get(), arguments);
+    }
+    return status;
+}

--- a/trusty-test/trusty-test.pro
+++ b/trusty-test/trusty-test.pro
@@ -1,0 +1,44 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2017-04-08T14:14:36
+#
+#-------------------------------------------------
+
+QT       += core testlib
+
+TARGET = trusty-test
+CONFIG   += console testcase
+CONFIG   -= app_bundle
+
+TEMPLATE = app
+
+# The following define makes your compiler emit warnings if you use
+# any feature of Qt which as been marked as deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+
+CONFIG += c++14
+
+DEFINES += ASIO_STANDALONE ASIO_HAS_STD_CHRONO ASIO_HAS_MOVE
+
+HEADERS += \
+    ProxyStateTest.h \
+    MessageProcessorTest.h
+
+SOURCES += \
+    main.cpp \
+    ProxyStateTest.cpp \
+    MessageProcessorTest.cpp
+
+DEFINES += SRCDIR=\\\"$$PWD/\\\"
+
+LIBS += -L$$OUT_PWD/../trusty-interface/ -ltrusty-interface
+
+INCLUDEPATH += \
+    $$PWD/../trusty-interface \
+    $$PWD/../trusty \
+    $$PWD/../include \
+
+DEPENDPATH += \
+    $$PWS/../trusty \


### PR DESCRIPTION
ProxyState is promoted to its own header, and MessageProcessor has its low-level socket code extracted into a new UnixSocket class.  This will let us test the fiddly bits so that they retain their nascent stability.