### PR TITLE
Serialize int32_t and uint32_t in big-endian order

### DIFF
--- a/trusty-interface/Bytes.h
+++ b/trusty-interface/Bytes.h
@@ -1,0 +1,58 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef BYTES_H
+#define BYTES_H
+
+#include <cassert>
+#include <cstdint>
+
+namespace ama { namespace trusty {
+
+namespace Bytes {
+
+template <typename T>
+inline T from_network_order(const uint8_t* bytes)
+{
+    static_assert(sizeof(T) == 4, "T must have a width of four bytes");
+
+    assert(bytes != nullptr);
+
+    return (static_cast<T>(bytes[0]) << 24)
+         | (static_cast<T>(bytes[1]) << 16)
+         | (static_cast<T>(bytes[2]) <<  8)
+         | (static_cast<T>(bytes[3])      );
+}
+
+template <typename T>
+inline void to_network_order(const T val, uint8_t* bytes)
+{
+    static_assert(sizeof(T) == 4, "T must have a width of four bytes");
+
+    assert(bytes != nullptr);
+
+    bytes[0] = static_cast<uint8_t>((val >> 24) & 0xFF);
+    bytes[1] = static_cast<uint8_t>((val >> 16) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((val >>  8) & 0xFF);
+    bytes[3] = static_cast<uint8_t>((val      ) & 0xFF);
+}
+
+} // namespace Bytes
+
+}} // ama::trusty
+
+#endif // BYTES_H

--- a/trusty-interface/MessageProcessor.h
+++ b/trusty-interface/MessageProcessor.h
@@ -127,7 +127,7 @@ struct Message
 
     void assign_u8_payload(uint8_t n);
     void assign_u32_payload(uint32_t n);
-    void assign_i32_payload(int n);
+    void assign_i32_payload(int32_t n);
     void assign_string_payload(const std::string &str);
 
     int get_i32_payload() const;

--- a/trusty-interface/UnixSocket.cpp
+++ b/trusty-interface/UnixSocket.cpp
@@ -170,7 +170,7 @@ void UnixSocket::checked_read(uint8_t* data, size_t len)
 
         if (num_read == 0)
         {
-            throw std::runtime_error("Connected is unexpectedly closed");
+            throw std::runtime_error("Connection is unexpectedly closed");
         }
 
         data += num_read;

--- a/trusty-interface/trusty-interface.pro
+++ b/trusty-interface/trusty-interface.pro
@@ -16,7 +16,8 @@ HEADERS += \
     Service.h \
     CFRef.h \
     ProxyState.h \
-    UnixSocket.h
+    UnixSocket.h \
+    Bytes.h
 
 SOURCES += \
     MessageProcessor.cpp \

--- a/trusty-test/BytesTest.h
+++ b/trusty-test/BytesTest.h
@@ -1,0 +1,34 @@
+// Amanuensis - Web Traffic Inspector
+//
+// Copyright (C) 2017 Benjamin Bader
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef BYTESTEST_H
+#define BYTESTEST_H
+
+#include <QObject>
+
+class BytesTest : public QObject
+{
+    Q_OBJECT
+public:
+    explicit BytesTest();
+
+private Q_SLOTS:
+    void to_network_order();
+    void from_network_order();
+};
+
+#endif // BYTESTEST_H

--- a/trusty-test/main.cpp
+++ b/trusty-test/main.cpp
@@ -23,7 +23,7 @@
 #include <QCoreApplication>
 #include <QtTest>
 
-// Include test files
+#include "BytesTest.h"
 #include "MessageProcessorTest.h"
 #include "ProxyStateTest.h"
 
@@ -33,7 +33,8 @@ int main(int argc, char **argv)
     QStringList arguments = QCoreApplication::arguments();
 
     std::unordered_map<std::string, std::unique_ptr<QObject>> tests;
-    tests.emplace("MessageProcessorTests", std::make_unique<MessageProcessorTest>());
+    tests.emplace("BytesTest", std::make_unique<BytesTest>());
+    tests.emplace("MessageProcessorTest", std::make_unique<MessageProcessorTest>());
     tests.emplace("ProxyStateTest", std::make_unique<ProxyStateTest>());
 
     int status = 0;

--- a/trusty-test/trusty-test.pro
+++ b/trusty-test/trusty-test.pro
@@ -24,12 +24,14 @@ DEFINES += ASIO_STANDALONE ASIO_HAS_STD_CHRONO ASIO_HAS_MOVE
 
 HEADERS += \
     ProxyStateTest.h \
-    MessageProcessorTest.h
+    MessageProcessorTest.h \
+    BytesTest.h
 
 SOURCES += \
     main.cpp \
     ProxyStateTest.cpp \
-    MessageProcessorTest.cpp
+    MessageProcessorTest.cpp \
+    BytesTest.cpp
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"
 


### PR DESCRIPTION
All the processors to which I'd imagine deploying are little-endian, and I can't imagine why we'd ever (in trusty) send data to a different processor architecture... but why leave things to chance?

It's also nicer to have bit-fiddling code consolidated.