### PR TITLE
Make HTTP 1.1 parsing incremental

### DIFF
--- a/app/MainWindow.h
+++ b/app/MainWindow.h
@@ -25,6 +25,8 @@
 #include <QStringListModel>
 #include <QVector>
 
+#include "Transaction.h"
+
 namespace ama
 {
 class Proxy;
@@ -34,6 +36,26 @@ namespace Ui {
 class MainWindow;
 }
 
+class TxListener : public QObject
+                 , public ama::TransactionListener
+                 , public std::enable_shared_from_this<TxListener>
+{
+    Q_OBJECT
+public:
+    void on_transaction_start(ama::Transaction &tx) override;
+    void on_request_read(ama::Transaction &tx) override;
+
+    void on_response_headers_read(ama::Transaction &tx) override;
+    void on_response_read(ama::Transaction &tx) override;
+
+    void on_transaction_complete(ama::Transaction &tx) override;
+
+    void on_transaction_failed(ama::Transaction &tx) override;
+
+signals:
+    void message_logged(const QString& message);
+};
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -42,12 +64,19 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
+    //void addRowToListView(const std::string& message);
+
+public slots:
+    void on_message_logged(const QString& message);
+
 private:
     //void addRowToListView(const std::shared_ptr<ama::Connection> &connection, const std::string &message);
+
 
 private:
     Ui::MainWindow *ui;
     std::shared_ptr<ama::Proxy> proxy;
+    std::shared_ptr<TxListener> txListener;
     QVector<QMetaObject::Connection> connections;
 
     QStringListModel *model;

--- a/core-test/HttpMessageParserTests.h
+++ b/core-test/HttpMessageParserTests.h
@@ -36,6 +36,8 @@ private Q_SLOTS:
     void simpleForbiddenResponse();
 
     void connectFromEdge();
+
+    void pauses_on_phase_transitions();
 };
 
 #endif

--- a/core/Transaction.h
+++ b/core/Transaction.h
@@ -45,15 +45,15 @@ class A_EXPORT TransactionListener
 public:
     virtual ~TransactionListener() {}
 
-    virtual void on_transaction_start(const Transaction &tx) = 0;
-    virtual void on_request_read(const Transaction &tx) = 0;
+    virtual void on_transaction_start(Transaction &tx) = 0;
+    virtual void on_request_read(Transaction &tx) = 0;
 
-    virtual void on_response_headers_read(const Transaction &tx) = 0;
-    virtual void on_response_read(const Transaction &tx) = 0;
+    virtual void on_response_headers_read(Transaction &tx) = 0;
+    virtual void on_response_read(Transaction &tx) = 0;
 
-    virtual void on_transaction_complete(const Transaction &tx) = 0;
+    virtual void on_transaction_complete(Transaction &tx) = 0;
 
-    virtual void on_transaction_failed(const Transaction &tx) = 0;
+    virtual void on_transaction_failed(Transaction &tx) = 0;
 };
 
 /**


### PR DESCRIPTION
Adding the concept of "phases" to parsing, and causing parsing to pause when a phase changes.  This lets us act e.g. when response headers have been received, before we begin handling the response entity.