### PR TITLE
Accept zero-prefixed chunk lengths

### DIFF
--- a/core-test/HttpMessageParserTests.cpp
+++ b/core-test/HttpMessageParserTests.cpp
@@ -298,3 +298,25 @@ void HttpMessageParserTests::pauses_on_phase_transitions()
     QCOMPARE(std::string{"abcdefghijklmnopqrstuvwxyz0123456789"}, request.body_as_string());
 }
 
+void HttpMessageParserTests::zero_prefixed_chunk_lengths()
+{
+    std::string text =
+            "HTTP/1.1 200 OK\r\n"
+            "Transfer-Encoding: chunked\r\n"
+            "\r\n"
+            "005\r\n"
+            "aaaaa\r\n"
+            "00000000\r\n"
+            "\r\n";
+
+    HttpMessage message;
+    HttpMessageParser parser;
+    parser.resetForResponse();
+
+    auto begin = text.begin();
+    auto end = text.end();
+    auto state = parser.parse(message, begin, end);
+
+    QCOMPARE(HttpMessageParser::State::Valid, state);
+}
+

--- a/core-test/HttpMessageParserTests.h
+++ b/core-test/HttpMessageParserTests.h
@@ -38,6 +38,8 @@ private Q_SLOTS:
     void connectFromEdge();
 
     void pauses_on_phase_transitions();
+
+    void zero_prefixed_chunk_lengths();
 };
 
 #endif

--- a/core/HttpMessageParser.h
+++ b/core/HttpMessageParser.h
@@ -183,16 +183,12 @@ private:
 
         chunk                            = 204,
         chunk_trailing_newline           = 205,
-        chunk_sequence_terminating_cr    = 206,
-        chunk_sequence_terminating_lf    = 207,
-        chunk_sequence_terminating_cr_2  = 208,
-        chunk_sequence_terminating_lf_2  = 209,
-        chunk_trailing_header_line_start = 210,
-        chunk_trailing_header_lws        = 211,
-        chunk_trailing_header_name       = 212,
-        chunk_trailing_header_space      = 213,
-        chunk_trailing_header_value      = 214,
-        chunk_terminating_newline        = 215,
+        chunk_trailing_header_line_start = 206,
+        chunk_trailing_header_lws        = 207,
+        chunk_trailing_header_name       = 208,
+        chunk_trailing_header_space      = 209,
+        chunk_trailing_header_value      = 210,
+        chunk_terminating_newline        = 211,
 
         // Non-chunked entities
         fixed_length_entity              = 300,


### PR DESCRIPTION
Our Transfer-Encoding: chunked implementation was not actually correct, and as a consequence was not robust to servers that improperly add leading zeroes to chunk lengths.  This is fixed here by more closely conforming to the RFC spec ourselves, and removing a few parse states that don't match the BNF defined there.

Fixes #23.